### PR TITLE
Fix bug on scan operation:

### DIFF
--- a/lib/warpath/enum_walker.ex
+++ b/lib/warpath/enum_walker.ex
@@ -104,7 +104,7 @@ defmodule Warpath.EnumRecursiveDescent do
     |> Enum.reverse()
   end
 
-  defp get_members({_, _} = element, _), do: element
+  defp get_members({_, _} = _element, _), do: []
 
   defp traverse({member, _} = element, acc, path_fun) when is_container(member) do
     element

--- a/lib/warpath/scanner.ex
+++ b/lib/warpath/scanner.ex
@@ -4,9 +4,11 @@ defmodule Warpath.Scanner do
   alias Warpath.Element.Path
   alias Warpath.EnumWalker
 
-  def scan(element, criteria, path_fun \\ &Path.accumulate/2)
+  def scan(element, criteria, tracker \\ &Path.accumulate/2) when is_function(tracker, 2) do
+    do_scan(element, criteria, tracker)
+  end
 
-  def scan(element, {:property, _} = criteria, path_fun) when is_function(path_fun, 2) do
+  defp do_scan(element, {:property, _} = criteria, _tracker) do
     walk_reducer = fn {_, path} = element, acc ->
       case path do
         [^criteria | _] ->
@@ -22,7 +24,7 @@ defmodule Warpath.Scanner do
     |> Enum.reverse()
   end
 
-  def scan(element, {:wildcard, :*}, path_fun) when is_function(path_fun, 2) do
-    EnumWalker.recursive_descent(element, path_fun)
+  defp do_scan(element, {:wildcard, :*}, tracker) do
+    EnumWalker.recursive_descent(element, tracker)
   end
 end


### PR DESCRIPTION
Ref: #9

- Do a wildcard scan on scalar value must return a empty list, ex: Warpath.query!(100, "$..*") => []
- Do a indexes scan when the document is a list should include it self, ex: Warpath.query!(["a", "b"], "$..[0]") => ["a"]