### PR TITLE
Fix bracket notation with positive number:

### DIFF
--- a/lib/warpath/exceptions.ex
+++ b/lib/warpath/exceptions.ex
@@ -2,6 +2,10 @@ defmodule Warpath.UnsupportedOperationError do
   defexception [:message]
 end
 
+defmodule Warpath.IndexNotFoundError do
+  defexception [:message]
+end
+
 defmodule Warpath.ExpressionError do
   defexception [:message]
 end

--- a/lib/warpath/exceptions.ex
+++ b/lib/warpath/exceptions.ex
@@ -2,10 +2,6 @@ defmodule Warpath.UnsupportedOperationError do
   defexception [:message]
 end
 
-defmodule Warpath.IndexNotFoundError do
-  defexception [:message]
-end
-
 defmodule Warpath.ExpressionError do
   defexception [:message]
 end

--- a/test/warpath_test.exs
+++ b/test/warpath_test.exs
@@ -211,7 +211,7 @@ defmodule WarpathTest do
 
   describe "query/3 handle array" do
     test "index access expression", %{data: document} do
-      trace = "$['store']['book'][0]"
+      path = "$['store']['book'][0]"
 
       book = %{
         "category" => "reference",
@@ -220,7 +220,7 @@ defmodule WarpathTest do
         "price" => 8.95
       }
 
-      assert Warpath.query(document, "$.store.book[0]", @value_path) == {:ok, [{book, trace}]}
+      assert Warpath.query(document, "$.store.book[0]", @value_path) == {:ok, {book, path}}
     end
 
     test "index access with many indexes", %{data: document} do
@@ -310,9 +310,9 @@ defmodule WarpathTest do
 
   describe "query/3 handle options" do
     test "result_type: :path", %{data: document} do
-      trace = "$['store']['book'][0]"
+      path = "$['store']['book'][0]"
 
-      assert Warpath.query(document, "$.store.book[0]", result_type: :path) == {:ok, [trace]}
+      assert Warpath.query(document, "$.store.book[0]", result_type: :path) == {:ok, path}
     end
 
     test "default result_type is value", %{data: document} do
@@ -323,7 +323,7 @@ defmodule WarpathTest do
         "title" => "Sayings of the Century"
       }
 
-      assert Warpath.query(document, "$.store.book[0]") == {:ok, [book]}
+      assert Warpath.query(document, "$.store.book[0]") == {:ok, book}
     end
   end
 


### PR DESCRIPTION
Ref: #9

Query that use array index access like $[0], should return a scalar value.
Ex.
```elixir
#Current behavior:
Warpath.query([:a, 1, 2], "$[0]")
{:ok, [:a]}

#After this PR
Warpath.query([0, 1, 2], "$[0]")
{:ok, :a}
```
