### PR TITLE
Allow single quote surround double quote and vice versa.

### DIFF
--- a/src/tokenizer.xrl
+++ b/src/tokenizer.xrl
@@ -6,74 +6,81 @@
 Definitions.
 
 % Ignored tokens
-WhiteSpace          = \x{0009}\x{000B}\x{000C}\x{0020}\x{00A0}
-_LineTerminator     = \x{000A}\x{000D}\x{2028}\x{2029}
-LineTerminator      = [{_LineTerminator}]
-Ignored             = [{WhiteSpace}]|{LineTerminator}
+WhiteSpace             = \x{0009}\x{000B}\x{000C}\x{0020}\x{00A0}
+_LineTerminator        = \x{000A}\x{000D}\x{2028}\x{2029}
+LineTerminator         = [{_LineTerminator}]
+Ignored                = [{WhiteSpace}]|{LineTerminator}
 
 %Especial Symbols
-At                  = \@
-Dollar              = \$
-OpenBracket         = \[
-CloseBracket        = \]
-OpenParens          = \(
-CloseParens         = \)
-Dot                 = \.
-QuestionMark        = \?
-Start               = \*
-Colon               = \:
-Comma               = \,
-RecursiveDescent    = {Dot}{Dot}
-Comparator          = (<|>|<=|>=|==|!=|===|!==)
-Boolean             = true|false
+At                     = \@
+Dollar                 = \$
+OpenBracket            = \[
+CloseBracket           = \]
+OpenParens             = \(
+CloseParens            = \)
+Dot                    = \.
+QuestionMark           = \?
+Start                  = \*
+Colon                  = \:
+Comma                  = \,
+SingleQuote            = '
+DoubleQuote            = "
+LintRack               = '
+RecursiveDescent       = {Dot}{Dot}
+Comparator             = (<|>|<=|>=|==|!=|===|!==)
+Boolean                = true|false
 
 % Int Value
-Digit               = [0-9]
-NegativeSign        = -
-IntegerPart         = {NegativeSign}?{Digit}+
-IntValue            = {IntegerPart}
+Digit                  = [0-9]
+NegativeSign           = -
+IntegerPart            = {NegativeSign}?{Digit}+
+IntValue               = {IntegerPart}
 
 % Float Value
-FractionalPart      = \.{Digit}+
-Sign                = [+\-]
-ExponentIndicator   = [eE]
-ExponentPart        = {ExponentIndicator}{Sign}?{Digit}+
-FloatValue          = ({IntegerPart}{FractionalPart}|{IntegerPart}{ExponentPart}|{IntegerPart}{FractionalPart}{ExponentPart})
+FractionalPart         = \.{Digit}+
+Sign                   = [+\-]
+ExponentIndicator      = [eE]
+ExponentPart           = {ExponentIndicator}{Sign}?{Digit}+
+FloatValue             = ({IntegerPart}{FractionalPart}|{IntegerPart}{ExponentPart}|{IntegerPart}{FractionalPart}{ExponentPart})
 
 
 % Punctuator
-_Punctuator         = {At}{Dollar}{OpenBracket}{CloseBracket}{OpenParens}{CloseParens}{Dot}{QuestionMark}{Start}{Colon}{Comma}
-Punctuator          = [{_Punctuator}]|{RecursiveDescent}
+_Punctuator            = {At}{Dollar}{OpenBracket}{CloseBracket}{OpenParens}{CloseParens}{Dot}{QuestionMark}{Start}{Colon}{Comma}
+Punctuator             = [{_Punctuator}]|{RecursiveDescent}
 
 
 % Identifier Value
-HexDigit            = [0-9A-Fa-f]
-EscapedUnicode      = u{HexDigit}{HexDigit}{HexDigit}{HexDigit}
-OperatorsSymbol     = ><=!
-EscapedCharacter    = ['"\\\/bfnrt]
-AllowedIdentifier   = [^"'{_LineTerminator}{_Punctuator}{WhiteSpace}{OperatorsSymbol}]
-EscapedSequence     = \\{EscapedUnicode}|\\{EscapedCharacter}|\\{_Punctuator}
+HexDigit               = [0-9A-Fa-f]
+EscapedUnicode         = u{HexDigit}{HexDigit}{HexDigit}{HexDigit}
+OperatorsSymbol        = ><=!
+EscapedCharacter       = [{SingleQuote}{DoubleQuote}\\\/bfnrt]
+AllowedIdentifier      = [^{SingleQuote}{DoubleQuote}{_LineTerminator}{_Punctuator}{WhiteSpace}{OperatorsSymbol}]
+EscapedSequence        = \\{EscapedUnicode}|\\{EscapedCharacter}|\\{_Punctuator}
 
-IdentifierCharacter = ({AllowedIdentifier}|{EscapedSequence})
-ToQuoteIdentifier   = ([^''{_LineTerminator}]|{EscapedSequence})
-Identifier          = {IdentifierCharacter}+
-QuotedIdentifier    = '({Identifier}|{ToQuoteIdentifier})*'
+IdentifierCharacter    = ({AllowedIdentifier}|{EscapedSequence})
+ToQuoteIdentifier      = ([^{SingleQuote}{DoubleQuote}{_LineTerminator}]|{EscapedSequence})
+Identifier             = {IdentifierCharacter}+
 
-
-%%%Atom
-AllowedUnicode      = [^'"'{_LineTerminator}]
-ToQuoteAtom         = ({AllowedUnicode}|{EscapedSequence})
-UnquotedAtom        = ([a-zA-Z_][0-9a-zA-Z_?!]*)
-DoubleQuotedAtom    = "({UnquotedAtom}|{ToQuoteAtom})*"
-SingleQuotedAtom    = '({UnquotedAtom}|{ToQuoteAtom})*'
-Atom                = :({UnquotedAtom}|{DoubleQuotedAtom}|{SingleQuotedAtom})
+% Quoted Identifier
+SingleQuotedIdentifier = '({DoubleQuote}|{Identifier}|{ToQuoteIdentifier})*'
+DoubleQuotedIdentifier = "({SingleQuote}|{Identifier}|{ToQuoteIdentifier})*"
+QuotedIdentifier       = {SingleQuotedIdentifier}|{DoubleQuotedIdentifier}
 
 
-%%Operators
-OrOp                = or|\|\|
-AndOp               = and|&&
-NotOp               = not
-InOp                = in
+% Atom
+AllowedUnicode         = [^{SingleQuote}{DoubleQuote}{_LineTerminator}]
+ToQuoteAtom            = ({AllowedUnicode}|{EscapedSequence})
+UnquotedAtom           = ([a-zA-Z_][0-9a-zA-Z_?!]*)
+DoubleQuotedAtom       = "({UnquotedAtom}|{ToQuoteAtom})*"
+SingleQuotedAtom       = '({UnquotedAtom}|{ToQuoteAtom})*'
+Atom                   = :({UnquotedAtom}|{DoubleQuotedAtom}|{SingleQuotedAtom})
+
+
+% Operators
+OrOp                   = or|\|\|
+AndOp                  = and|&&
+NotOp                  = not
+InOp                   = in
 
 
 
@@ -83,41 +90,37 @@ Rules.
 {AndOp}                 : {token, {and_op,          TokenLine}}.
 {NotOp}                 : {token, {not_op,          TokenLine}}.
 {InOp}                  : {token, {in_op,           TokenLine}}.
-
-{Punctuator}            : {token, {list_to_atom(TokenChars), TokenLine}}.
 {Boolean}               : {token, {boolean,         TokenLine, list_to_atom(TokenChars)}}.
 {Atom}                  : {token, {word,            TokenLine, to_atom(TokenChars)}}.
 
+{Punctuator}            : {token, {list_to_atom(TokenChars), TokenLine}}.
 {Comparator}            : {token, {comparator,      TokenLine, list_to_atom(TokenChars)}}.
 {FloatValue}            : {token, {float,           TokenLine, list_to_float(TokenChars)}}.
 {IntValue}              : {token, {int,             TokenLine, list_to_integer(TokenChars)}}.
 {Identifier}            : {token, {word,            TokenLine, unicode:characters_to_binary(TokenChars)}}.
-{QuotedIdentifier}      : {token, {quoted_word,     TokenLine, single_quoted_word_to_binary(TokenChars)}}.
-{Ignored}               : skip_token.
+{QuotedIdentifier}      : {token, {quoted_word,     TokenLine, quoted_word_to_binary(TokenChars)}}.
+{Ignored}+              : skip_token.
 
 
 
 Erlang code.
 
-single_quoted_word_to_binary([$', $']) -> <<>>;
-single_quoted_word_to_binary([$' | Chars]) ->
-    Char = lists:last(Chars),
-    case Char of
-      $' -> unicode:characters_to_binary(lists:droplast(Chars));
-      Other -> {error, Other}
+match_drop_last(List, Char) when is_list(List) ->
+    Last = lists:last(List),
+    if Last == Char -> lists:droplast(List);
+       true -> {error, Last}
     end.
 
+quoted_word_to_binary([$', $']) -> <<>>;
+quoted_word_to_binary([$", $"]) -> <<>>;
+quoted_word_to_binary([SingleQuote | Chars])
+    when SingleQuote == $'; SingleQuote == $" ->
+    Word = match_drop_last(Chars, SingleQuote),
+    unicode:characters_to_binary(Word).
+
 to_atom([$: | Chars]) -> to_atom(Chars);
-to_atom([$" | Chars]) ->
-  Char = lists:last(Chars),
-  case Char of
-    $" -> to_atom(lists:droplast(Chars));
-    Other -> {error, Other}
-  end;
-to_atom([$' | Chars]) ->
-  Char = lists:last(Chars),
-  case Char of
-    $' -> to_atom(lists:droplast(Chars));
-    Other -> {error, Other}
-  end;
+to_atom([SingleQuote | Chars])
+    when SingleQuote == $'; SingleQuote == $" ->
+    Word = match_drop_last(Chars, SingleQuote),
+    to_atom(Word);
 to_atom(Chars) -> list_to_atom(Chars).

--- a/test/fixtures/json_comparision_regration_suite.yaml
+++ b/test/fixtures/json_comparision_regration_suite.yaml
@@ -577,7 +577,7 @@ queries:
     selector: $[?(@.key=="hi@example.com")]
     document: [{"key": "some"}, {"key": "value"}, {"key": "hi@example.com"}]
   - id: filter_expression_with_equals_on_string_with_dot_literal
-    warpath: skip
+    warpath: run
     selector: $[?(@.key=="some.value")]
     document: [{"key": "some"}, {"key": "value"}, {"key": "some.value"}]
     consensus: [{"key": "some.value"}]

--- a/test/warpath/expression_test.exs
+++ b/test/warpath/expression_test.exs
@@ -62,13 +62,11 @@ defmodule Warpath.ExpressionTest do
     end
 
     test "double quote surround by single quoted" do
-      assert Expression.compile(~S{$."'"}) ==
-               {:ok, [{:root, "$"}, {:dot, {:property, "'"}}]}
+      assert Expression.compile(~S{$."'"}) == {:ok, [{:root, "$"}, {:dot, {:property, "'"}}]}
     end
 
     test "single quote surround by double quoted" do
-      assert Expression.compile(~S{$.'"'}) ==
-               {:ok, [{:root, "$"}, {:dot, {:property, "\""}}]}
+      assert Expression.compile(~S{$.'"'}) == {:ok, [{:root, "$"}, {:dot, {:property, "\""}}]}
     end
   end
 

--- a/test/warpath/expression_test.exs
+++ b/test/warpath/expression_test.exs
@@ -60,6 +60,16 @@ defmodule Warpath.ExpressionTest do
       assert Expression.compile(~S{$.:atom_key}) ==
                {:ok, [{:root, "$"}, {:dot, {:property, :atom_key}}]}
     end
+
+    test "double quote surround by single quoted" do
+      assert Expression.compile(~S{$."'"}) ==
+               {:ok, [{:root, "$"}, {:dot, {:property, "'"}}]}
+    end
+
+    test "single quote surround by double quoted" do
+      assert Expression.compile(~S{$.'"'}) ==
+               {:ok, [{:root, "$"}, {:dot, {:property, "\""}}]}
+    end
   end
 
   describe "compile/1 compile scan" do

--- a/test/warpath/tokenizer_test.exs
+++ b/test/warpath/tokenizer_test.exs
@@ -128,6 +128,14 @@ defmodule Warpath.TokenizerTest do
     test "unicode symbol" do
       assert Tokenizer.tokenize("🌢") == {:ok, [{:word, 1, "🌢"}]}
     end
+
+    test "double quote surround by single quote token" do
+      assert Tokenizer.tokenize(~S/'"'/) == {:ok, [{:quoted_word, 1, "\""}]}
+    end
+
+    test "single quote surround by dougle quote" do
+      assert Tokenizer.tokenize(~S/"name'"/) == {:ok, [{:quoted_word, 1, "name'"}]}
+    end
   end
 
   test "tokenize/1 should return {:error, reason} for nested single quote" do


### PR DESCRIPTION
This allow query property like that:
`$."name's"` or `$.'Double"Quote'`

Fix double quoted property query, ref #9. 