### PR TITLE
Keep operators hidden

### DIFF
--- a/lib/warpath/query/array_index_operator.ex
+++ b/lib/warpath/query/array_index_operator.ex
@@ -4,6 +4,8 @@ alias Warpath.Execution.Env
 alias Warpath.Query.IndexOperator
 
 defprotocol IndexOperator do
+  @moduledoc false
+
   @fallback_to_any true
 
   @type document :: list()

--- a/lib/warpath/query/descendant_operator.ex
+++ b/lib/warpath/query/descendant_operator.ex
@@ -6,6 +6,8 @@ alias Warpath.Query.DescendantOperator
 alias Warpath.Query.FilterOperator
 
 defprotocol DescendantOperator do
+  @moduledoc false
+
   @fallback_to_any true
 
   @type document :: list() | map()

--- a/lib/warpath/query/filter_operator.ex
+++ b/lib/warpath/query/filter_operator.ex
@@ -7,6 +7,8 @@ alias Warpath.Filter.Predicate
 alias Warpath.Query.FilterOperator
 
 defprotocol FilterOperator do
+  @moduledoc false
+
   @fallback_to_any true
 
   @type document :: map() | list()

--- a/lib/warpath/query/identifier_operator.ex
+++ b/lib/warpath/query/identifier_operator.ex
@@ -10,6 +10,8 @@ alias Warpath.Query.UnionOperator
 alias Warpath.Query.WildcardOperator
 
 defprotocol IdentifierOperator do
+  @moduledoc false
+
   @type document :: map | keyword() | list(Element.t())
 
   @type relative_path :: ElementPath.t() | []

--- a/lib/warpath/query/slice_operator.ex
+++ b/lib/warpath/query/slice_operator.ex
@@ -5,6 +5,8 @@ alias Warpath.Expression
 alias Warpath.Query.SliceOperator
 
 defprotocol SliceOperator do
+  @moduledoc false
+
   @fallback_to_any true
 
   @type document :: list()

--- a/lib/warpath/query/union_operator.ex
+++ b/lib/warpath/query/union_operator.ex
@@ -6,6 +6,8 @@ alias Warpath.Query.UnionOperator
 alias Warpath.Query.IdentifierOperator
 
 defprotocol UnionOperator do
+  @moduledoc false
+
   @type document :: map() | keyword() | list(Element.t())
 
   @type result :: [Element.t()]

--- a/lib/warpath/query/wildcard_operator.ex
+++ b/lib/warpath/query/wildcard_operator.ex
@@ -6,6 +6,8 @@ alias Warpath.Expression
 alias Warpath.Query.WildcardOperator
 
 defprotocol WildcardOperator do
+  @moduledoc false
+
   @fallback_to_any true
 
   @type document :: map() | list()


### PR DESCRIPTION
Keep hidden on documentation until Api stay stable.