### PR TITLE
Evaluate property or index that doesn't exist will produce nil and an empty path

### DIFF
--- a/lib/warpath.ex
+++ b/lib/warpath.ex
@@ -184,7 +184,7 @@ defmodule Warpath do
       ...> Warpath.query(document, "$[?( @[2] )]") # That means give me all list that have index 2.
       {:ok, [ [1,2,3], [9,8,7]] }
 
-  ### Recursive descent
+  ### Recursive descendant
 
       #Collect key
       iex>document = %{"store" => %{"car" => %{"price" => 100_000}, "bicycle" => %{"price" => 500}}}
@@ -202,7 +202,6 @@ defmodule Warpath do
       {:ok, [ [1, 2], [], [9, 8]]}
 
   ### Options
-      #default
       iex>document = %{"integers" => [100, 200, 300]}
       ...> Warpath.query(document, "$.integers")
       {:ok, [100, 200, 300]}
@@ -249,7 +248,7 @@ defmodule Warpath do
   ## Options:
     result_type:
     * `:value` - return the value of evaluated expression - `default`
-    * `:path` - return the bracketfiy path string of evaluated expression instead of it's value
+    * `:path` - return the bracketfiy path string representation of evaluated expression instead of it's value
     * `:value_path` - return both value and bracketify path string.
     * `:path_tokens` - return the path tokens instead of it string representation, see `Warpath.Element.Path`.
     * `:value_path_tokens` - return both value and path tokens.

--- a/lib/warpath.ex
+++ b/lib/warpath.ex
@@ -202,6 +202,11 @@ defmodule Warpath do
       {:ok, [ [1, 2], [], [9, 8]]}
 
   ### Options
+      #default
+      iex>document = %{"integers" => [100, 200, 300]}
+      ...> Warpath.query(document, "$.integers")
+      {:ok, [100, 200, 300]}
+
       iex>document = %{"integers" => [100, 200, 300]}
       ...> Warpath.query(document, "$.integers[0, 1]", result_type: :path)
       {:ok, ["$['integers'][0]", "$['integers'][1]"]}
@@ -223,7 +228,6 @@ defmodule Warpath do
   alias Warpath.Execution
   alias Warpath.Execution.Env
   alias Warpath.Expression
-  alias Warpath.Query.RootOperator
 
   @doc """
   Query data for the given expression.
@@ -244,9 +248,9 @@ defmodule Warpath do
 
   ## Options:
     result_type:
-    * `:value` -  return the value of evaluated expression - `default`
-    * `:path` - return the path of evaluated expression instead of it's value
-    * `:value_path` - return both value and path.
+    * `:value` - return the value of evaluated expression - `default`
+    * `:path` - return the bracketfiy path string of evaluated expression instead of it's value
+    * `:value_path` - return both value and bracketify path string.
     * `:path_tokens` - return the path tokens instead of it string representation, see `Warpath.Element.Path`.
     * `:value_path_tokens` - return both value and path tokens.
   """
@@ -302,11 +306,6 @@ defmodule Warpath do
       {:ok, query_result} -> query_result
       {:error, error} -> raise error
     end
-  end
-
-  defp dispatch(%Env{operator: operator}, %Element{value: nil} = element)
-       when operator != RootOperator do
-    {:halt, element}
   end
 
   defp dispatch(%Env{operator: operator} = env, elements) when is_list(elements) do

--- a/lib/warpath/element/path.ex
+++ b/lib/warpath/element/path.ex
@@ -59,7 +59,7 @@ defmodule Warpath.Element.Path do
     |> List.flatten()
   end
 
-  defp make_path([], _), do: []
+  defp make_path([], _), do: ""
 
   defp to_string(tokens, opts) do
     tokens

--- a/lib/warpath/query/identifier_operator.ex
+++ b/lib/warpath/query/identifier_operator.ex
@@ -24,11 +24,16 @@ end
 defimpl IdentifierOperator, for: Map do
   def evaluate(document, relative_path, %Env{instruction: instruction}) do
     {:dot, {:property, identifier} = token} = instruction
-    path = Element.Path.accumulate(token, relative_path)
 
-    document
-    |> Access.get(identifier)
-    |> Element.new(path)
+    if Accessible.has_key?(document, identifier) do
+      path = Element.Path.accumulate(token, relative_path)
+
+      document
+      |> Access.get(identifier)
+      |> Element.new(path)
+    else
+      Element.new(nil, [])
+    end
   end
 end
 
@@ -43,11 +48,10 @@ defimpl IdentifierOperator, for: List do
     end)
   end
 
-  def evaluate(elements, relative_path, %Env{instruction: {:dot, property}} = env) do
+  def evaluate(elements, relative_path, env) do
     case {elements, Keyword.keyword?(elements)} do
       {_, false} ->
-        path = Element.Path.accumulate(property, relative_path)
-        Element.new(nil, path)
+        Element.new(nil, [])
 
       {keyword, true} ->
         IdentifierOperator.Map.evaluate(keyword, relative_path, env)
@@ -58,5 +62,5 @@ defimpl IdentifierOperator, for: List do
 end
 
 defimpl IdentifierOperator, for: Atom do
-  def evaluate(nil, relative_path, _), do: Element.new(nil, relative_path)
+  def evaluate(_, _relative_path, _), do: Element.new(nil, [])
 end

--- a/lib/warpath/query/index_operator.ex
+++ b/lib/warpath/query/index_operator.ex
@@ -33,7 +33,7 @@ defimpl IndexOperator, for: List do
 
   def evaluate(document, path, %Env{instruction: {:indexes, [index]}}) do
     if out_of_bound?(index, document) do
-      Element.new(nil, Element.Path.accumulate(index, path))
+      Element.new(nil, [])
     else
       [element] = value_for_indexes(document, path, [index])
       element
@@ -68,8 +68,9 @@ defimpl IndexOperator, for: List do
 end
 
 defimpl IndexOperator, for: Any do
-  def evaluate(_, path, %Env{instruction: {:indexes, [index]}}) do
-    Element.new(nil, Element.Path.accumulate(index, path))
+  def evaluate(_, _path, %Env{instruction: {:indexes, [_]}}) do
+    # Produce scalar result
+    Element.new(nil, [])
   end
 
   def evaluate(_, _, _), do: []

--- a/lib/warpath/query/union_operator.ex
+++ b/lib/warpath/query/union_operator.ex
@@ -54,5 +54,5 @@ defimpl UnionOperator, for: List do
 end
 
 defimpl UnionOperator, for: Atom do
-  def evaluate(nil, _, _), do: []
+  def evaluate(_, _, _), do: []
 end

--- a/test/warpath/element/path_test.exs
+++ b/test/warpath/element/path_test.exs
@@ -41,6 +41,10 @@ defmodule Warpath.Element.PathTest do
       tokens = Enum.map(nested_tokens, &accumulate_tokens(&1))
       assert Path.bracketify(tokens) == ["$['persons'][0]['name']", "$['persons'][1]['name']"]
     end
+
+    test "empty list" do
+      assert Path.bracketify([]) == ""
+    end
   end
 
   describe "dotify/1 create path for" do
@@ -78,6 +82,10 @@ defmodule Warpath.Element.PathTest do
 
       tokens = Enum.map(nested_tokens, &accumulate_tokens(&1))
       assert Path.dotify(tokens) == ["$.persons[0].name", "$.persons[1].name"]
+    end
+
+    test "empty list" do
+      assert Path.dotify([]) == ""
     end
   end
 

--- a/test/warpath/query/identifier_operator_test.exs
+++ b/test/warpath/query/identifier_operator_test.exs
@@ -23,21 +23,15 @@ defmodule Warpath.Query.IdentifierOperatorTest do
       end
     end
 
-    property "evaluate a non existent property always create a element with value nil" do
+    property "evaluate a non existent property always create a element with value nil with empty path" do
       unique = make_ref()
 
       check all map <- map_of(term(), term(), min_length: 1) do
-        element = Element.new(nil, [{:property, unique} | @relative_path])
+        element = Element.new(nil, [])
 
         assert IdentifierOperator.evaluate(map, @relative_path, env_evaluation_for(unique)) ==
                  element
       end
-    end
-
-    test "evaluate a property on empty map" do
-      result = IdentifierOperator.evaluate(%{}, @relative_path, env_evaluation_for("any"))
-
-      assert result == Element.new(nil, [{:property, "any"} | @relative_path])
     end
   end
 
@@ -99,14 +93,14 @@ defmodule Warpath.Query.IdentifierOperatorTest do
       assert IdentifierOperator.evaluate(elements_with_keyword_list, [], env) == expected
     end
 
-    test "evaluate a empty list always result in nil" do
+    test "evaluate a empty list always result in element with nil value and empty path" do
       assert IdentifierOperator.evaluate([], @relative_path, env_evaluation_for(:any)) ==
-               Element.new(nil, [{:property, :any} | @relative_path])
+               Element.new(nil, [])
     end
   end
 
   test "evaluate/3 is nil safe" do
     assert IdentifierOperator.evaluate(nil, @relative_path, env_evaluation_for("propery_name")) ==
-             Element.new(nil, @relative_path)
+             Element.new(nil, [])
   end
 end

--- a/test/warpath/query/index_operator_test.exs
+++ b/test/warpath/query/index_operator_test.exs
@@ -29,20 +29,20 @@ defmodule Warpath.Query.IndexOperatorTest do
       end
     end
 
-    property "always produce a nil value for positive out of bound index" do
+    property "always produce a element with nil value and empty path for positive out of bound index" do
       check all terms <- list_of(term()),
                 count = length(terms) do
         result = IndexOperator.evaluate(terms, @relative_path, env_for_indexes([count]))
-        assert result == Element.new(nil, [{:index_access, count} | @relative_path])
+        assert result == Element.new(nil, [])
       end
     end
 
-    property "always produce a nil value for negative out of bound index" do
+    property "always produce a element with nil value and empty path for negative out of bound index" do
       check all terms <- list_of(term()),
                 count = length(terms) do
         out_of_bound = -(count + 1)
         result = IndexOperator.evaluate(terms, @relative_path, env_for_indexes([out_of_bound]))
-        assert result == Element.new(nil, [{:index_access, out_of_bound} | @relative_path])
+        assert result == Element.new(nil, [])
       end
     end
 
@@ -51,7 +51,7 @@ defmodule Warpath.Query.IndexOperatorTest do
 
       check all term <- term() do
         result = IndexOperator.evaluate(term, @relative_path, env)
-        assert is_list(term) or result == Element.new(nil, [{:index_access, 0} | @relative_path])
+        assert is_list(term) or result == Element.new(nil, [])
       end
     end
   end

--- a/test/warpath_test.exs
+++ b/test/warpath_test.exs
@@ -35,18 +35,6 @@ defmodule WarpathTest do
       assert {:ok, "Warpath"} =
                Warpath.query(~S/{"autobots": ["Optimus Prime", "Warpath"]}/, "$.autobots[1]")
     end
-
-    test "halt evaluation early when reaches nil value" do
-      document = %{"name" => "warpath"}
-
-      assert {:ok, {nil, "$['bla']"}} ==
-               Warpath.query(document, "$.bla", result_type: :value_path)
-
-      assert {:ok, {nil, "$['bla']"}} ==
-               Warpath.query(document, "$.bla.bla.bla", result_type: :value_path)
-
-      assert {:ok, {nil, "$"}} == Warpath.query(nil, "$.bla", result_type: :value_path)
-    end
   end
 
   describe "query!/3" do


### PR DESCRIPTION
When evaluate a selector that should produce a scalar value and the selector path does't exist warpath will produce a `nil` with it path empty. For selector that produce list of items, in that case a list with out that element will be returned.

Close #85 