### PR TITLE
allow property access on filters with no matches

### DIFF
--- a/lib/warpath.ex
+++ b/lib/warpath.ex
@@ -100,6 +100,7 @@ defmodule Warpath do
     {label_of(output), output}
   end
 
+  defp label_of([]), do: :halt
   defp label_of({:error, _}), do: :halt
   defp label_of(_), do: :cont
 

--- a/lib/warpath/query/accessible.ex
+++ b/lib/warpath/query/accessible.ex
@@ -7,7 +7,7 @@ defmodule Warpath.Query.Accessible do
 
   def has_key?(%{} = accessible, key), do: Map.has_key?(accessible, key)
 
-  def has_key?(keywords, key) when is_list(keywords),
+  def has_key?(keywords, key) when is_list(keywords) and is_atom(key),
     do: Keyword.keyword?(keywords) and Keyword.has_key?(keywords, key)
 
   def has_key?(_, _), do: false

--- a/test/fixtures/json_comparision_regrassion_suite.yaml
+++ b/test/fixtures/json_comparision_regrassion_suite.yaml
@@ -329,7 +329,7 @@ queries:
   - id: dot_notation_after_filter_expression_with_no_matching_entries
     selector: "$[?(@.id==0)].name"
     document: [{"id": 42, "name": "forty-two"}, {"id": 1, "name": "one"}]
-    consensus: null
+    consensus: []
   - id: dot_notation_after_filter_expression_with_mismatched_results
     selector: "$[?(@.id > 0)].name"
     document: [{"id": 42, "name": "forty-two"}, {"id": 1}, {"id": 0, "name": "zero"}]

--- a/test/fixtures/json_comparision_regrassion_suite.yaml
+++ b/test/fixtures/json_comparision_regrassion_suite.yaml
@@ -326,6 +326,14 @@ queries:
     selector: "$[?(@.id==42)].name"
     document: [{"id": 42, "name": "forty-two"}, {"id": 1, "name": "one"}]
     consensus: ["forty-two"]
+  - id: dot_notation_after_filter_expression_with_no_matching_entries
+    selector: "$[?(@.id==0)].name"
+    document: [{"id": 42, "name": "forty-two"}, {"id": 1, "name": "one"}]
+    consensus: null
+  - id: dot_notation_after_filter_expression_with_mismatched_results
+    selector: "$[?(@.id > 0)].name"
+    document: [{"id": 42, "name": "forty-two"}, {"id": 1}, {"id": 0, "name": "zero"}]
+    consensus: ["forty-two"]
   - id: dot_notation_after_recursive_descent
     selector: "$..key"
     document: {"object": {"key": "value", "array": [{"key": "something"}, {"key": {"key": "russian dolls"}}]}, "key": "top"}

--- a/test/warpath/query/accessible_test.exs
+++ b/test/warpath/query/accessible_test.exs
@@ -27,6 +27,7 @@ defmodule Warpath.Query.AccessibleTest do
 
     refute Accessible.has_key?([], :b)
     refute Accessible.has_key?(%{}, "b")
+    refute Accessible.has_key?([], "b")
 
     refute Accessible.has_key?(:atom, :a)
     refute Accessible.has_key?("", :a)

--- a/test/warpath_test.exs
+++ b/test/warpath_test.exs
@@ -59,6 +59,12 @@ defmodule WarpathTest do
       assert "Warpath" =
                Warpath.query!(~S/{"autobots": ["Optimus Prime", "Warpath"]}/, "$.autobots[1]")
     end
+
+    test "an empty list is returned for queries that filter out all possible matches", %{
+      data: document
+    } do
+      assert Warpath.query!(document, "$.store.book[?(@.id == 0)].title") == []
+    end
   end
 
   describe "query/3 handle options" do


### PR DESCRIPTION
This takes care of https://github.com/Cleidiano/warpath/issues/92

I'm not sure if the `test/fixtures/json_comparision_regrassion_suite.yaml` file is the right place to document this edge case, but I tried it put it in near some other tests that were dealing with filters and property access.

In the original issue I had mentioned that I would expect this edge case to return `[]` since it has no list entries that match the  filter, but when testing this scenario on jsonpath.com it looks like it considers this a "No Match" (screenshot below). That seems to match the `nil` case for this library so I made my new tests expect `nil`.

<img width="1341" alt="Screen Shot 2020-10-01 at 9 04 02 PM" src="https://user-images.githubusercontent.com/80008/94884073-ac8ca200-0429-11eb-9cd4-1aa615e9577b.png">
